### PR TITLE
Add travis checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.3.3


### PR DESCRIPTION
Turn on automated checking with travis (currently only that we pass `rubocop`)