### PR TITLE
Switch term 21 to unstable URL

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -19,6 +19,7 @@ ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
 26.downto(1) do |t|
   url = "https://tr.wikipedia.org/wiki/TBMM_#{t}._d%C3%B6nem_milletvekilleri_listesi"
+  url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_21._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 21
   url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_18._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 18
   url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_16._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 16
   url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_9._d%C3%B6nem_milletvekilleri_listesi&stable=0'  if t == 9

--- a/scraper.rb
+++ b/scraper.rb
@@ -20,9 +20,6 @@ ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 26.downto(1) do |t|
   url = "https://tr.wikipedia.org/wiki/TBMM_#{t}._d%C3%B6nem_milletvekilleri_listesi"
   url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_21._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 21
-  url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_18._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 18
-  url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_16._d%C3%B6nem_milletvekilleri_listesi&stable=0' if t == 16
-  url = 'https://tr.wikipedia.org/w/index.php?title=TBMM_9._d%C3%B6nem_milletvekilleri_listesi&stable=0'  if t == 9
   response = Scraped::Request.new(url: url).response
   data = TermPage.new(response: response).members
   warn "#{t}: #{data.count}"


### PR DESCRIPTION
This scraper was failing because "Mustafa Gül" wasn't a link on the term 21 Wikipedia page. This change updates the scraper to point at the unstable version of the term 21 Wikipedia page.

You can see [my update to the term 21 Wikipedia page here](https://tr.wikipedia.org/w/index.php?title=TBMM_21._d%C3%B6nem_milletvekilleri_listesi&oldid=18193167). 

Fixes https://github.com/everypolitician/everypolitician-data/issues/25707